### PR TITLE
PHP 8 compatibility: mysqli error flow, InnoDB DDL, modern deps, Rector 8.3 sweep

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,11 @@
         }
     },
     "require": {
-        "symfony/var-dumper": "^3.4",
-        "filp/whoops": "^2.1",
+        "php": "^8.1",
+        "symfony/var-dumper": "^5.4",
+        "filp/whoops": "^2.15",
         "larapack/dd": "^1.1",
-        "league/flysystem": "^1.0",
-        "psr/log": "^1.0"
+        "league/flysystem": "^1.1",
+        "psr/log": "^1.1"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,33 +1,33 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "82b52ac5f945aee165e443629d0a3405",
+    "content-hash": "83e2a13e328cceb669f655e289f3b577",
     "packages": [
         {
             "name": "filp/whoops",
-            "version": "2.1.14",
+            "version": "2.18.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filp/whoops.git",
-                "reference": "c6081b8838686aa04f1e83ba7e91f78b7b2a23e6"
+                "reference": "d2102955e48b9fd9ab24280a7ad12ed552752c4d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filp/whoops/zipball/c6081b8838686aa04f1e83ba7e91f78b7b2a23e6",
-                "reference": "c6081b8838686aa04f1e83ba7e91f78b7b2a23e6",
+                "url": "https://api.github.com/repos/filp/whoops/zipball/d2102955e48b9fd9ab24280a7ad12ed552752c4d",
+                "reference": "d2102955e48b9fd9ab24280a7ad12ed552752c4d",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9 || ^7.0",
-                "psr/log": "^1.0.1"
+                "php": "^7.1 || ^8.0",
+                "psr/log": "^1.0.1 || ^2.0 || ^3.0"
             },
             "require-dev": {
-                "mockery/mockery": "0.9.*",
-                "phpunit/phpunit": "^4.8.35 || ^5.7",
-                "symfony/var-dumper": "^2.6 || ^3.0"
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.8 || ^9.3.3",
+                "symfony/var-dumper": "^4.0 || ^5.0"
             },
             "suggest": {
                 "symfony/var-dumper": "Pretty print complex values better with var-dumper available",
@@ -36,7 +36,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "2.7-dev"
                 }
             },
             "autoload": {
@@ -65,7 +65,17 @@
                 "throwable",
                 "whoops"
             ],
-            "time": "2017-11-23T18:22:44+00:00"
+            "support": {
+                "issues": "https://github.com/filp/whoops/issues",
+                "source": "https://github.com/filp/whoops/tree/2.18.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/denis-sokolov",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-08T12:00:00+00:00"
         },
         {
             "name": "larapack/dd",
@@ -101,35 +111,39 @@
                 }
             ],
             "description": "`dd` is a helper method in Laravel. This package will add the `dd` to your application.",
+            "support": {
+                "issues": "https://github.com/larapack/dd/issues",
+                "source": "https://github.com/larapack/dd/tree/master"
+            },
             "time": "2016-12-15T09:34:34+00:00"
         },
         {
             "name": "league/flysystem",
-            "version": "1.0.45",
+            "version": "1.1.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "a99f94e63b512d75f851b181afcdf0ee9ebef7e6"
+                "reference": "3239285c825c152bcc315fe0e87d6b55f5972ed1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/a99f94e63b512d75f851b181afcdf0ee9ebef7e6",
-                "reference": "a99f94e63b512d75f851b181afcdf0ee9ebef7e6",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/3239285c825c152bcc315fe0e87d6b55f5972ed1",
+                "reference": "3239285c825c152bcc315fe0e87d6b55f5972ed1",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "ext-fileinfo": "*",
+                "league/mime-type-detection": "^1.3",
+                "php": "^7.2.5 || ^8.0"
             },
             "conflict": {
                 "league/flysystem-sftp": "<1.0.6"
             },
             "require-dev": {
-                "ext-fileinfo": "*",
-                "phpspec/phpspec": "^3.4",
-                "phpunit/phpunit": "^5.7"
+                "phpspec/prophecy": "^1.11.1",
+                "phpunit/phpunit": "^8.5.8"
             },
             "suggest": {
-                "ext-fileinfo": "Required for MimeType",
                 "ext-ftp": "Allows you to use FTP server storage",
                 "ext-openssl": "Allows you to use FTPS server storage",
                 "league/flysystem-aws-s3-v2": "Allows you to use S3 storage with AWS SDK v2",
@@ -185,20 +199,86 @@
                 "sftp",
                 "storage"
             ],
-            "time": "2018-05-07T08:44:23+00:00"
+            "support": {
+                "issues": "https://github.com/thephpleague/flysystem/issues",
+                "source": "https://github.com/thephpleague/flysystem/tree/1.1.10"
+            },
+            "funding": [
+                {
+                    "url": "https://offset.earth/frankdejonge",
+                    "type": "other"
+                }
+            ],
+            "time": "2022-10-04T09:16:37+00:00"
         },
         {
-            "name": "psr/log",
-            "version": "1.0.2",
+            "name": "league/mime-type-detection",
+            "version": "1.17.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/php-fig/log.git",
-                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d"
+                "url": "https://github.com/thephpleague/mime-type-detection.git",
+                "reference": "f5f47eff7c48ed1003069a2ca67f316fb4021c76"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
-                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "url": "https://api.github.com/repos/thephpleague/mime-type-detection/zipball/f5f47eff7c48ed1003069a2ca67f316fb4021c76",
+                "reference": "f5f47eff7c48ed1003069a2ca67f316fb4021c76",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.2",
+                "phpstan/phpstan": "^0.12.68",
+                "phpunit/phpunit": "^8.5.8 || ^9.3 || ^10.0 || ^11.0 || ^12.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\MimeTypeDetection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frankdejonge.nl"
+                }
+            ],
+            "description": "Mime-type detection for Flysystem",
+            "support": {
+                "issues": "https://github.com/thephpleague/mime-type-detection/issues",
+                "source": "https://github.com/thephpleague/mime-type-detection/tree/1.17.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/frankdejonge",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/league/flysystem",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-09T11:49:27+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
                 "shasum": ""
             },
             "require": {
@@ -207,7 +287,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
@@ -222,7 +302,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common interface for logging libraries",
@@ -232,41 +312,49 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2016-10-10T12:19:37+00:00"
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/1.1.4"
+            },
+            "time": "2021-05-03T11:20:27+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.8.0",
+            "version": "v1.38.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "3296adf6a6454a050679cde90f95350ad604b171"
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/3296adf6a6454a050679cde90f95350ad604b171",
-                "reference": "3296adf6a6454a050679cde90f95350ad604b171",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "ext-iconv": "*",
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-mbstring": "*"
             },
             "suggest": {
                 "ext-mbstring": "For best performance"
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-master": "1.8-dev"
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Mbstring\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -291,44 +379,152 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-04-26T10:06:28+00:00"
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.2"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-27T06:59:30+00:00"
         },
         {
-            "name": "symfony/var-dumper",
-            "version": "v3.4.9",
+            "name": "symfony/polyfill-php80",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "0e6545672d8c9ce70dd472adc2f8b03155a46f73"
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/0e6545672d8c9ce70dd472adc2f8b03155a46f73",
-                "reference": "0e6545672d8c9ce70dd472adc2f8b03155a46f73",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "symfony/polyfill-mbstring": "~1.0"
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:19:22+00:00"
+        },
+        {
+            "name": "symfony/var-dumper",
+            "version": "v5.4.48",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-dumper.git",
+                "reference": "42f18f170aa86d612c3559cfb3bd11a375df32c8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/42f18f170aa86d612c3559cfb3bd11a375df32c8",
+                "reference": "42f18f170aa86d612c3559cfb3bd11a375df32c8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php80": "^1.16"
             },
             "conflict": {
-                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
+                "symfony/console": "<4.4"
             },
             "require-dev": {
                 "ext-iconv": "*",
-                "twig/twig": "~1.34|~2.4"
+                "symfony/console": "^4.4|^5.0|^6.0",
+                "symfony/http-kernel": "^4.4|^5.0|^6.0",
+                "symfony/process": "^4.4|^5.0|^6.0",
+                "symfony/uid": "^5.1|^6.0",
+                "twig/twig": "^2.13|^3.0.4"
             },
             "suggest": {
                 "ext-iconv": "To convert non-UTF-8 strings to UTF-8 (or symfony/polyfill-iconv in case ext-iconv cannot be used).",
                 "ext-intl": "To show region name in time zone dump",
-                "ext-symfony_debug": ""
+                "symfony/console": "To use the ServerDumpCommand and/or the bin/var-dump-server script"
             },
+            "bin": [
+                "Resources/bin/var-dump-server"
+            ],
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4-dev"
-                }
-            },
             "autoload": {
                 "files": [
                     "Resources/functions/dump.php"
@@ -354,21 +550,41 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony mechanism for exploring and dumping PHP variables",
+            "description": "Provides mechanisms for walking through any arbitrary PHP variable",
             "homepage": "https://symfony.com",
             "keywords": [
                 "debug",
                 "dump"
             ],
-            "time": "2018-04-26T12:42:15+00:00"
+            "support": {
+                "source": "https://github.com/symfony/var-dumper/tree/v5.4.48"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-11-08T15:21:10+00:00"
         }
     ],
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": []
+    "platform": {
+        "php": "^8.1"
+    },
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }

--- a/handlers/mail.php
+++ b/handlers/mail.php
@@ -1,7 +1,7 @@
 <?php
 
 // read input
-@list($scriptPath, $hostname, $recipient, $sender, $queueId) = $argv;
+@[$scriptPath, $hostname, $recipient, $sender, $queueId] = $argv;
 
 if (!$hostname || !$recipient || !$sender || !$queueId) {
     print("One or more required parameters missing\n");
@@ -31,7 +31,7 @@ if (is_readable($hostmapPath)) {
         $hostnames = array_unique(array_merge([$config['primary_hostname']], $config['hostnames']));
 
         foreach ($hostnames AS $hostname) {
-            $hostmap['/^'.str_replace('\\*', '.*', preg_quote($hostname)).'$/i'] = basename($sitePath);
+            $hostmap['/^'.str_replace('\\*', '.*', preg_quote((string) $hostname)).'$/i'] = basename($sitePath);
         }
     }
 
@@ -43,7 +43,7 @@ if (is_readable($hostmapPath)) {
 // TODO: move this to a static Site method getHandleFromHostname, have initialize use it if hostname isn't provided (and swap initialize param order)
 $siteHandle = null;
 foreach ($hostmap AS $pattern => $patternHandle) {
-    if (preg_match($pattern, $hostname)) {
+    if (preg_match($pattern, (string) $hostname)) {
         $siteHandle = $patternHandle;
         break;
     }

--- a/src-compat/Cache.php
+++ b/src-compat/Cache.php
@@ -34,7 +34,7 @@ class Cache
         if (function_exists('apcu_delete')) {
             return apcu_delete($key);
         } elseif (function_exists('apc_delete')) {
-            return apc_delete($key, $value, $ttl);
+            return apc_delete($key);
         } else {
             unset(static::$fallbackCache[$key]);
             return true;
@@ -46,7 +46,7 @@ class Cache
         if (function_exists('apcu_exists')) {
             return apcu_exists($key);
         } elseif (function_exists('apc_exists')) {
-            return apc_exists($key, $value, $ttl);
+            return apc_exists($key);
         } else {
             return array_key_exists($key, static::$fallbackCache);
         }
@@ -125,12 +125,12 @@ class Cache
     public static function getIterator($pattern)
     {
         // sanity check pattern
-        if (!preg_match('/^(.).+\1[a-zA-Z]*$/', $pattern)) {
+        if (!preg_match('/^(.).+\1[a-zA-Z]*$/', (string) $pattern)) {
             throw new Exception('Cache iterator pattern doesn\'t appear to have matching delimiters');
         }
 
         // modify pattern to insert key prefix and isolate matches to this site
-        $prefixPattern = preg_quote(static::getKeyPrefix());
+        $prefixPattern = preg_quote((string) static::getKeyPrefix());
         if ($pattern[1] == '^') {
             $pattern = substr_replace($pattern, $prefixPattern, 2, 0);
         } else {

--- a/src-compat/CacheIterator.php
+++ b/src-compat/CacheIterator.php
@@ -20,7 +20,7 @@ if (class_exists('APCUIterator', false)) {
         {
             $data = parent::current();
 
-            return extension_loaded('apcu') && version_compare(phpversion('apcu'), '4.0.3') < 0 ? array(
+            return extension_loaded('apcu') && version_compare(phpversion('apcu'), '4.0.3') < 0 ? [
                 'type' => 'user'
                 ,'key' => $data['key']
                 ,'value' => $data['value']
@@ -32,7 +32,7 @@ if (class_exists('APCUIterator', false)) {
                 ,'ref_count' => $data['ref_count']
                 ,'mem_size' => $data['mem_size']
                 ,'ttl' => $data['ttl']
-            ) : $data;
+            ] : $data;
         }
     }
 }

--- a/src-compat/DB.php
+++ b/src-compat/DB.php
@@ -359,6 +359,11 @@ class DB
     // protected static methods
     protected static function preprocessQuery($query, $parameters = null)
     {
+        // PHP 8 live runtime: MySQL 8 retires MyISAM (disabled outright on Cloud
+        // SQL); rewrite legacy hardcoded engine declarations at the query choke
+        // point (mirrors infra/archive/image/patch-core-db.sh on the archive track)
+        $query = str_replace('ENGINE=MyISAM', 'ENGINE=InnoDB', $query);
+
         if (empty($parameters)) {
             return $query;
         }
@@ -452,6 +457,12 @@ class DB
                 'username' => null,
                 'password' => null
             ), Site::getConfig('database'));
+
+            // PHP >= 8.1 defaults mysqli to MYSQLI_REPORT_ERROR|MYSQLI_REPORT_STRICT;
+            // restore errno-based error flow -- ActiveRecord's on-demand table
+            // creation catches TableNotFoundException raised from DB::handleError's
+            // errno checks, which never run if mysqli throws mysqli_sql_exception
+            mysqli_report(MYSQLI_REPORT_OFF);
 
             // connect to mysql database, ignoring connection errors
             $mysqli = @new mysqli($config['host'], $config['username'], $config['password'], null, $config['port'], $config['socket']);

--- a/src-compat/DB.php
+++ b/src-compat/DB.php
@@ -8,7 +8,7 @@ class DB
 
     // protected properties
     protected static $_mysqli;
-    protected static $_record_cache = array();
+    protected static $_record_cache = [];
 
     // public static methods
     public static function escape($string)
@@ -118,9 +118,9 @@ class DB
         // execute query
         $result = self::query($query, $parameters);
 
-        $records = array();
+        $records = [];
         while ($record = $result->fetch_assoc()) {
-            $records[$record[$tableKey] ? $record[$tableKey] : $nullKey] = $record;
+            $records[$record[$tableKey] ?: $nullKey] = $record;
         }
 
         // free result
@@ -134,10 +134,10 @@ class DB
         // execute query
         $result = self::query($query, $parameters);
 
-        $records = array();
+        $records = [];
         while ($record = $result->fetch_assoc()) {
             if (!array_key_exists($record[$tableKey], $records)) {
-                $records[$record[$tableKey]] = array();
+                $records[$record[$tableKey]] = [];
             }
 
             $records[$record[$tableKey]][] = $record;
@@ -154,7 +154,7 @@ class DB
         // execute query
         $result = self::query($query, $parameters);
 
-        $records = array();
+        $records = [];
         while ($record = $result->fetch_assoc()) {
             $records[$record[$tableKey]] = $record[$valueKey];
         }
@@ -170,7 +170,7 @@ class DB
         // execute query
         $result = self::query($query, $parameters);
 
-        $records = array();
+        $records = [];
         while ($record = $result->fetch_assoc()) {
             foreach ($classMapping AS $key => $class) {
                 $record[$key] = new $class($record[$key]);
@@ -190,11 +190,11 @@ class DB
         // execute query
         try {
             $result = self::query($query, $parameters);
-        } catch (TableNotFoundException $e) {
+        } catch (TableNotFoundException) {
             return [];
         }
 
-        $records = array();
+        $records = [];
         while ($record = $result->fetch_assoc()) {
             $records[] = new $className($record);
         }
@@ -212,11 +212,11 @@ class DB
         // execute query
         try {
             $result = self::query($query, $parameters);
-        } catch (TableNotFoundException $e) {
+        } catch (TableNotFoundException) {
             return [];
         }
 
-        $records = array();
+        $records = [];
         while ($record = $result->fetch_assoc()) {
             $records[] = $record;
         }
@@ -232,11 +232,11 @@ class DB
         // execute query
         try {
             $result = self::query($query, $parameters);
-        } catch (TableNotFoundException $e) {
+        } catch (TableNotFoundException) {
             return [];
         }
 
-        $records = array();
+        $records = [];
         while ($record = $result->fetch_assoc()) {
             $records[] = $record[$valueKey];
         }
@@ -257,12 +257,12 @@ class DB
         // check for cached record
         if (array_key_exists($cacheKey, self::$_record_cache)) {
             // log cache hit
-            Debug::log(array(
+            Debug::log([
                 'cache_hit' => true
                 ,'query' => $query
                 ,'cache_key' => $cacheKey
                 ,'method' => __FUNCTION__
-            ));
+            ]);
 
             // return cache hit
             return self::$_record_cache[$cacheKey];
@@ -271,7 +271,7 @@ class DB
         // preprocess and execute query
         try {
             $result = self::query($query, $parameters);
-        } catch (TableNotFoundException $e) {
+        } catch (TableNotFoundException) {
             return null;
         }
 
@@ -300,7 +300,7 @@ class DB
         // preprocess and execute query
         try {
             $result = self::query($query, $parameters);
-        } catch (TableNotFoundException $e) {
+        } catch (TableNotFoundException) {
             return null;
         }
 
@@ -336,7 +336,7 @@ class DB
         }
     }
 
-    public static function makeOrderString($order = array())
+    public static function makeOrderString($order = [])
     {
         $s = '';
 
@@ -391,10 +391,10 @@ class DB
         }
 
         // create a new query log structure
-        return array(
+        return [
             'query' => $query
             ,'time_start' => sprintf('%f',microtime(true))
-        );
+        ];
     }
 
     protected static function extendQueryLog(&$queryLog, $key, $value)
@@ -432,7 +432,7 @@ class DB
                 continue;
             }
 
-            if (empty($backtick['class']) || $backtick['class'] != __CLASS__) {
+            if (empty($backtick['class']) || $backtick['class'] != self::class) {
                 break;
             }
 
@@ -450,13 +450,13 @@ class DB
     public static function getMysqli()
     {
         if (!isset(self::$_mysqli)) {
-            $config = array_merge(array(
+            $config = array_merge([
                 'host' => 'localhost',
                 'port' => 3306,
                 'socket' => null,
                 'username' => null,
                 'password' => null
-            ), Site::getConfig('database'));
+            ], Site::getConfig('database'));
 
             // PHP >= 8.1 defaults mysqli to MYSQLI_REPORT_ERROR|MYSQLI_REPORT_STRICT;
             // restore errno-based error flow -- ActiveRecord's on-demand table

--- a/src-compat/Debug.php
+++ b/src-compat/Debug.php
@@ -2,7 +2,7 @@
 
 class Debug
 {
-    public static $log = array();
+    public static $log = [];
 
     public static function dump($var, $exit = true, $title = null)
     {
@@ -40,7 +40,7 @@ class Debug
 
     public static function logMessage($message, $source = null)
     {
-        return static::log(array('message' => $message), $source);
+        return static::log(['message' => $message], $source);
     }
 
     public static function log($entry, $source = null)
@@ -49,10 +49,10 @@ class Debug
             return;
         }
 
-        static::$log[] = array_merge($entry, array(
-            'source' => isset($source) ? $source : static::_detectSource()
+        static::$log[] = array_merge($entry, [
+            'source' => $source ?? static::_detectSource()
             ,'time' => sprintf('%f', microtime(true))
-        ));
+        ]);
     }
 
     protected static function _detectSource()
@@ -61,7 +61,7 @@ class Debug
 
         while ($trace = array_shift($backtrace)) {
             if (!empty($trace['class'])) {
-                if ($trace['class'] == __CLASS__) {
+                if ($trace['class'] == self::class) {
                     continue;
                 }
                 return $trace['class'];
@@ -74,7 +74,7 @@ class Debug
     }
 
     protected static $_traceHandle;
-    public static function writeTrace($message, $data = array())
+    public static function writeTrace($message, $data = [])
     {
         if (!static::$_traceHandle) {
             $filePath = Site::$rootPath.'/site-data/trace-logs/';

--- a/src-compat/DuplicateKeyException.php
+++ b/src-compat/DuplicateKeyException.php
@@ -7,7 +7,7 @@ class DuplicateKeyException extends Exception
 
     public function __construct($message, $code = 0, Exception $previous = null)
     {
-        if (preg_match('/Duplicate entry \'(?<value>[^\']+)\' for key \'(?<key>[^\']+)\'/', $message, $matches)) {
+        if (preg_match('/Duplicate entry \'(?<value>[^\']+)\' for key \'(?<key>[^\']+)\'/', (string) $message, $matches)) {
             $this->duplicateKey = $matches['key'];
             $this->duplicateValue = $matches['value'];
         }

--- a/src-compat/Emergence.php
+++ b/src-compat/Emergence.php
@@ -20,19 +20,19 @@ class Emergence
 
         if ($_REQUEST['remote'] == 'parent') {
             set_time_limit(1800);
-            $remoteParams = array();
+            $remoteParams = [];
             if (!empty($_REQUEST['exclude'])) {
                 $remoteParams['exclude'] = $_REQUEST['exclude'];
             }
             if (!empty($_REQUEST['minId'])) {
                 $remoteParams['minId'] = $_REQUEST['minId'];
             }
-            HttpProxy::relayRequest(array(
+            HttpProxy::relayRequest([
                 'url' => static::buildUrl(Site::$pathStack, $remoteParams)
                 ,'autoAppend' => false
                 ,'autoQuery' => false
                 ,'timeout' => 500
-            ));
+            ]);
         }
 
         if (empty(Site::$pathStack[0])) {
@@ -55,15 +55,15 @@ class Emergence
     {
         set_time_limit(1800);
         $rootPath = $rootNode ? $rootNode->getFullPath(null, false) : null;
-        $collectionConditions = array();
-        $fileConditions = array();
+        $collectionConditions = [];
+        $fileConditions = [];
 
         // process excludes
         if (!empty($_REQUEST['exclude']) && method_exists('Emergence_FS', 'getNodesFromPattern')) {
-            $excludes = is_array($_REQUEST['exclude']) ? $_REQUEST['exclude'] : array($_REQUEST['exclude']);
+            $excludes = is_array($_REQUEST['exclude']) ? $_REQUEST['exclude'] : [$_REQUEST['exclude']];
 
-            $excludedCollections = array();
-            $excludedFiles = array();
+            $excludedCollections = [];
+            $excludedFiles = [];
 
             foreach (Emergence_FS::getNodesFromPattern($excludes) AS $node) {
                 if ($node->Class == 'SiteCollection') {
@@ -92,14 +92,14 @@ class Emergence
 
         header('HTTP/1.1 300 Multiple Choices');
         header('Content-Type: application/vnd.emergence.tree+json');
-        print(json_encode(array(
+        print(json_encode([
             'total' => count($files)
             ,'files' => $files
-        )));
+        ]));
         exit();
     }
 
-    public static function buildUrl($path = array(), $params = array())
+    public static function buildUrl($path = [], $params = [])
     {
         $params['accessKey'] = Site::getConfig('parent_key');
 
@@ -131,18 +131,18 @@ class Emergence
         fseek($fp, 0);
 
         // read and check status
-        list($protocol, $status, $message) = explode(' ', trim(fgetss($fp)));
+        [$protocol, $status, $message] = explode(' ', trim(fgetss($fp)));
 
-        return array(
+        return [
             'status' => (int)$status,
             'protocol' => $protocol,
             'message' => $message,
             'type' => curl_getinfo($ch, CURLINFO_CONTENT_TYPE),
             'resource' => $fp
-        );
+        ];
     }
 
-    public static function resolveFileFromParent($collection, $path, $forceRemote = false, $params = array())
+    public static function resolveFileFromParent($collection, $path, $forceRemote = false, $params = [])
     {
         if (!Site::getConfig('parent_hostname')) {
             return false;
@@ -199,7 +199,7 @@ class Emergence
                 if (!$header) {
                     break;
                 }
-                list($key, $value) = preg_split('/:\s*/', $header, 2);
+                [$key, $value] = preg_split('/:\s*/', $header, 2);
                 $key = strtolower($key);
 
                 // if etag found, use it to skip write if existing file matches

--- a/src-compat/Emergence_FS.php
+++ b/src-compat/Emergence_FS.php
@@ -5,23 +5,21 @@
  * hashes are not currently available outside the VFS implementation, and this allows them to
  * be returned without being calculated unless/until they're used
  */
-class Emergence_FS_Deferred_SHA1
+class Emergence_FS_Deferred_SHA1 implements \Stringable
 {
-    private $path;
     private $hash;
 
-    public function __construct($path)
+    public function __construct(private $path)
     {
-        $this->path = $path;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         if (!$this->hash) {
             $this->hash = sha1_file(SiteFile::getRealPathByID($this->path));
         }
 
-        return $this->hash;
+        return (string) $this->hash;
     }
 }
 
@@ -33,7 +31,7 @@ class Emergence_FS
         return 0;
     }
 
-    public static function getTree($path = null, $localOnly = false, $includeDeleted = false, $conditions = [])
+    public static function getTree($path = null, $localOnly = false, $includeDeleted = false, $conditions = []): never
     {
         throw new Exception('TODO: implement getTree');
     }
@@ -101,22 +99,22 @@ class Emergence_FS
         return $files;
     }
 
-    public static function getTreeFilesFromTree($tree, $conditions = [])
+    public static function getTreeFilesFromTree($tree, $conditions = []): never
     {
         throw new Exception('TODO: implement getTreeFilesFromTree');
     }
 
-    public static function exportTree($sourcePath, $destinationPath, $options = [])
+    public static function exportTree($sourcePath, $destinationPath, $options = []): never
     {
         throw new Exception('TODO: implement exportTree');
     }
 
-    public static function importFile($sourcePath, $destinationPath)
+    public static function importFile($sourcePath, $destinationPath): never
     {
         throw new Exception('TODO: implement importFile');
     }
 
-    public static function importTree($sourcePath, $destinationPath, $options = [])
+    public static function importTree($sourcePath, $destinationPath, $options = []): never
     {
         throw new Exception('TODO: implement importTree');
     }
@@ -129,7 +127,7 @@ class Emergence_FS
         return $tmpPath;
     }
 
-    public static function getCollectionLayers($path, $localOnly = false)
+    public static function getCollectionLayers($path, $localOnly = false): never
     {
         throw new Exception('TODO: implement getCollectionLayers');
     }
@@ -189,7 +187,7 @@ class Emergence_FS
         return $children;
     }
 
-    public static function getNodesFromPattern($patterns, $localOnly = false)
+    public static function getNodesFromPattern($patterns, $localOnly = false): never
     {
         throw new Exception('TODO: implement getNodesFromPattern');
     }
@@ -198,7 +196,7 @@ class Emergence_FS
     {
         if ($excludes) {
             foreach ($excludes as $excludePattern) {
-                if (preg_match($excludePattern, $relPath)) {
+                if (preg_match($excludePattern, (string) $relPath)) {
                     return true;
                 }
             }

--- a/src-compat/Emergence_Stream_Wrapper.php
+++ b/src-compat/Emergence_Stream_Wrapper.php
@@ -97,7 +97,7 @@ class Emergence_Stream_Wrapper
                 $mode |= 0040000;
             }
 
-            return array(
+            return [
                 'dev' => 0
                 ,'ino' => 0
                 ,'mode' => $mode
@@ -111,13 +111,13 @@ class Emergence_Stream_Wrapper
                 ,'ctime' => $timestamp
                 ,'blksize' => -1
                 ,'blocks' => -1
-            );
+            ];
         }
     }
 
     public static function is_real_path($path)
     {
-        return (strpos($path, Site::$rootPath) === 0);
+        return (str_starts_with((string) $path, (string) Site::$rootPath));
     }
 
     public static function get_real_handle($path)
@@ -131,7 +131,7 @@ class Emergence_Stream_Wrapper
         $fp = @fopen($path, 'r');
 
         stream_wrapper_unregister('file');
-        stream_wrapper_register('file', __CLASS__);
+        stream_wrapper_register('file', self::class);
 
         return $fp;
     }
@@ -139,7 +139,7 @@ class Emergence_Stream_Wrapper
     public static function get_virtual_path($path)
     {
         if ($path[0] == '/') {
-            return substr($path, 1);
+            return substr((string) $path, 1);
         } else {
             return 'site-root/'.$path;
         }

--- a/src-compat/HttpProxy.php
+++ b/src-compat/HttpProxy.php
@@ -5,7 +5,7 @@ class HttpProxy
     // config properties
     public static $debugMode = false;
     public static $sourceInterface = false; // string=hostname or IP, null=http hostname, false=let cURL pick
-    public static $defaultPassthruHeaders = array(
+    public static $defaultPassthruHeaders = [
         '/^HTTP\//'
         ,'/^Content-Type:/'
         ,'/^X-Powered-By:/'
@@ -16,23 +16,23 @@ class HttpProxy
         ,'/^ETag:/'
         ,'/^Last-Modified:/'
         ,'/^Author:/'
-    );
-    public static $defaultForwardHeaders = array(
+    ];
+    public static $defaultForwardHeaders = [
         'Content-Type'
         ,'User-Agent'
         ,'Accept'
         ,'Accept-Charset'
         ,'Accept-Language'
-    );
+    ];
 
     public static function relayRequest($options)
     {
         if (is_string($options)) {
-            $options = array('url' => $options);
+            $options = ['url' => $options];
         }
 
         if (!isset($options['headers'])) {
-            $options['headers'] = array();
+            $options['headers'] = [];
         }
 
         if (!isset($options['passthruHeaders'])) {
@@ -44,11 +44,11 @@ class HttpProxy
         }
 
         if (!isset($options['interface'])) {
-            $options['interface'] = isset(static::$sourceInterface) ? static::$sourceInterface : $_SERVER['HTTP_HOST'];
+            $options['interface'] = static::$sourceInterface ?? $_SERVER['HTTP_HOST'];
         }
 
         if (!isset($options['method'])) {
-            $options['method'] = isset($_SERVER['REQUEST_METHOD']) ? $_SERVER['REQUEST_METHOD'] : 'GET';
+            $options['method'] = $_SERVER['REQUEST_METHOD'] ?? 'GET';
         }
 
         if (!isset($options['debug'])) {
@@ -73,7 +73,7 @@ class HttpProxy
 
         // build headers
         foreach ($options['forwardHeaders'] AS $header) {
-            $headerKey = 'HTTP_'.str_replace('-', '_', strtoupper($header));
+            $headerKey = 'HTTP_'.str_replace('-', '_', strtoupper((string) $header));
 
             if (!empty($_SERVER[$headerKey])) {
                 $options['headers'][] = $header.': '.$_SERVER[$headerKey];
@@ -97,7 +97,7 @@ class HttpProxy
             curl_setopt($ch, CURLOPT_TIMEOUT, $options['timeout']);
         }
 
-        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, isset($options['timeoutConnect']) ? $options['timeoutConnect'] : 5);
+        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $options['timeoutConnect'] ?? 5);
 
         // process response headers
         $responseHeaders = null;
@@ -111,17 +111,17 @@ class HttpProxy
             print_r($options);
             print('</pre>');
         } else {
-            $responseHeaders = array();
+            $responseHeaders = [];
             curl_setopt($ch, CURLOPT_HEADER, false);
             curl_setopt($ch, CURLOPT_HEADERFUNCTION, function ($ch, $header) use ($options, &$responseHeaders) {
-                $headerLength = strlen($header);
-                @list($headerKey, $headerValue) = array_pad(preg_split('/:\s*/', $header, 2), 2, null);
+                $headerLength = strlen((string) $header);
+                @[$headerKey, $headerValue] = array_pad(preg_split('/:\s*/', (string) $header, 2), 2, null);
                 if ($headerKey && $headerValue) {
                     $responseHeaders[$headerKey] = trim($headerValue);
                 }
 
                 foreach ($options['passthruHeaders'] AS $pattern) {
-                    if (preg_match($pattern, $header)) {
+                    if (preg_match($pattern, (string) $header)) {
                         // apply header transformation
                         if (!empty($options['headerTransformer'])) {
                             $header = call_user_func($options['headerTransformer'], $header);
@@ -160,9 +160,7 @@ class HttpProxy
             if (is_string($options['cookies'])) {
                 $cookieStr = $options['cookies'];
             } else {
-                $cookieStr = implode('; ', array_map(function ($key, $value) {
-                    return $key.'='.urlencode($value);
-                }, array_keys($options['cookies']), $options['cookies']));
+                $cookieStr = implode('; ', array_map(fn($key, $value) => $key.'='.urlencode((string) $value), array_keys($options['cookies']), $options['cookies']));
             }
 
             curl_setopt($ch, CURLOPT_COOKIE, $cookieStr);
@@ -185,20 +183,20 @@ class HttpProxy
             print_r(curl_getinfo($ch));
             print('</pre>');
             print('<h1>cURL error</h1><pre>'.var_export(curl_error($ch), true).'</pre>');
-            print('<h1>Response Length</h1>'.strlen($responseBody));
+            print('<h1>Response Length</h1>'.strlen((string) $responseBody));
             print('<h1>Response Body</h1><pre>');
-            print(htmlspecialchars($responseBody));
+            print(htmlspecialchars((string) $responseBody));
             print('</pre>');
         } elseif (!empty($options['returnResponse'])) {
             $curlInfo = curl_getinfo($ch);
             curl_close($ch);
-            return array(
+            return [
                 'headers' => $responseHeaders,
                 'body' => $responseBody,
                 'info' => $curlInfo
-            );
+            ];
         } elseif ($responseBody !== false) {
-            header('Content-Length: '.strlen($responseBody));
+            header('Content-Length: '.strlen((string) $responseBody));
             print($responseBody);
         } else {
             header('HTTP/1.1 502 Bad Gateway');

--- a/src-compat/Site.php
+++ b/src-compat/Site.php
@@ -36,7 +36,7 @@ class Site
     protected static $_rootCollections;
     protected static $_config;
 
-    public static function initialize($rootPath, $hostname = null, array $config)
+    public static function initialize($rootPath, $hostname = null, array $config = [])
     {
         static::$initializeTime = microtime(true);
 

--- a/src-compat/Site.php
+++ b/src-compat/Site.php
@@ -12,9 +12,9 @@ class Site
     public static $onInitialized;
     public static $onNotFound;
     public static $onRequestMapped;
-    public static $permittedOrigins = array();
+    public static $permittedOrigins = [];
     public static $autoPull = true;
-    public static $skipSessionPaths = array();
+    public static $skipSessionPaths = [];
     public static $onSiteCreated;
     public static $onBeforeScriptExecute;
     public static $onBeforeStaticResponse;
@@ -24,15 +24,15 @@ class Site
     public static $rootPath;
     public static $webmasterEmail = 'root@localhost';
     public static $requestURI;
-    public static $requestPath = array();
-    public static $pathStack = array();
-    public static $resolvedPath = array();
+    public static $requestPath = [];
+    public static $pathStack = [];
+    public static $resolvedPath = [];
     public static $resolvedNode;
     public static $config; // TODO: deprecated; use Site::getConfig(...)
     public static $initializeTime;
 
     // protected properties
-    protected static $_loadedClasses = array();
+    protected static $_loadedClasses = [];
     protected static $_rootCollections;
     protected static $_config;
 
@@ -53,14 +53,12 @@ class Site
             $debugHandler = new \Whoops\Handler\PrettyPageHandler();
             $debugHandler->addDataTableCallback(
                 'Routing',
-                function () {
-                    return [
-                        'requestPath' => implode('/', Site::$requestPath),
-                        'resolvedPath' => implode('/', Site::$resolvedPath),
-                        'resolvedNode' => Site::$resolvedNode ? Site::$resolvedNode->FullPath : null,
-                        'pathStack' => implode('/', Site::$pathStack)
-                    ];
-                }
+                fn() => [
+                    'requestPath' => implode('/', Site::$requestPath),
+                    'resolvedPath' => implode('/', Site::$resolvedPath),
+                    'resolvedNode' => Site::$resolvedNode ? Site::$resolvedNode->FullPath : null,
+                    'pathStack' => implode('/', Site::$pathStack)
+                ]
             );
             $whoops->pushHandler($debugHandler);
         } else {
@@ -112,11 +110,11 @@ class Site
         if (!empty($_SERVER['REQUEST_URI'])) {
             $path = $_SERVER['REQUEST_URI'];
 
-            if (false !== ($qPos = strpos($path, '?'))) {
-                $path = substr($path, 0, $qPos);
+            if (false !== ($qPos = strpos((string) $path, '?'))) {
+                $path = substr((string) $path, 0, $qPos);
             }
 
-            $path = rawurldecode($path);
+            $path = rawurldecode((string) $path);
 
             static::$pathStack = static::$requestPath = static::splitPath($path);
         }
@@ -136,10 +134,10 @@ class Site
         }
 
         // register class loader
-        spl_autoload_register('Site::loadClass');
+        spl_autoload_register(Site::loadClass(...));
 
         // check virtual system for site config
-        static::loadConfig(__CLASS__);
+        static::loadConfig(self::class);
 
         // load all bootstraps scripts
         foreach (static::getFilesystem()->listContents('php-bootstraps') as $bootstrapFile) {
@@ -165,7 +163,7 @@ class Site
             call_user_func(static::$onInitialized);
         }
 
-        if (class_exists('Emergence\\EventBus')) {
+        if (class_exists(\Emergence\EventBus::class)) {
             Emergence\EventBus::fireEvent('initialized', 'Site');
         }
     }
@@ -177,12 +175,12 @@ class Site
             try {
                 $userClass = User::getStaticDefaultClass();
 
-                $User = $userClass::create(array_merge($requestData['create_user'], array(
+                $User = $userClass::create(array_merge($requestData['create_user'], [
                     'AccountLevel' => 'Developer'
-                )));
+                ]));
                 $User->setClearPassword($requestData['create_user']['Password']);
                 $User->save();
-            } catch (Exception $e) {
+            } catch (Exception) {
                 // fail silently
             }
         }
@@ -192,7 +190,7 @@ class Site
             call_user_func(static::$onSiteCreated, $requestData);
         }
 
-        if (class_exists('Emergence\\EventBus')) {
+        if (class_exists(\Emergence\EventBus::class)) {
             Emergence\EventBus::fireEvent('siteCreated', 'Site', $requestData);
         }
     }
@@ -206,7 +204,7 @@ class Site
         ) {
             $hostname = strtolower(parse_url($_SERVER['HTTP_ORIGIN'], PHP_URL_HOST));
             if (
-                $hostname == strtolower(static::$hostname)
+                $hostname == strtolower((string) static::$hostname)
                 || (!empty($_SERVER['HTTP_HOST']) && $hostname == strtolower($_SERVER['HTTP_HOST']))
                 || static::$permittedOrigins == '*'
                 || in_array($hostname, static::$permittedOrigins)
@@ -252,15 +250,15 @@ class Site
             call_user_func(static::$onRequestMapped, static::$resolvedNode);
         }
 
-        if (class_exists('Emergence\\EventBus')) {
-            Emergence\EventBus::fireEvent('requestMapped', 'Site', array(
+        if (class_exists(\Emergence\EventBus::class)) {
+            Emergence\EventBus::fireEvent('requestMapped', 'Site', [
                 'node' => static::$resolvedNode
-            ));
+            ]);
         }
 
         // if resolved node is a collection, look for _index.php
         if (is_a(static::$resolvedNode, 'SiteCollection')) {
-            $indexNode = static::resolvePath(array_merge($pathResult['searchPath'], array('_index.php')));
+            $indexNode = static::resolvePath(array_merge($pathResult['searchPath'], ['_index.php']));
 
             if ($indexNode) {
                 // switch resolvedNode to the index script
@@ -278,15 +276,15 @@ class Site
         }
 
         // output response
-        if (is_callable(array(static::$resolvedNode, 'outputAsResponse'))) {
+        if (is_callable([static::$resolvedNode, 'outputAsResponse'])) {
             if (is_callable(static::$onBeforeStaticResponse)) {
                 call_user_func(static::$onBeforeStaticResponse, static::$resolvedNode);
             }
 
-            if (class_exists('Emergence\\EventBus')) {
-                Emergence\EventBus::fireEvent('beforeStaticResponse', 'Site', array(
+            if (class_exists(\Emergence\EventBus::class)) {
+                Emergence\EventBus::fireEvent('beforeStaticResponse', 'Site', [
                     'node' => static::$resolvedNode
-                ));
+                ]);
             }
 
             static::$resolvedNode->outputAsResponse();
@@ -300,7 +298,7 @@ class Site
     {
         // results returned at end:
         $resolvedNode = null;
-        $resolvedPath = array();
+        $resolvedPath = [];
 
         // normalize args
         if (is_string($path)) {
@@ -309,16 +307,16 @@ class Site
 
         // rewrite empty path to default page
         if (empty($path[0]) && static::$defaultPage) {
-            $path = array(static::$defaultPage);
+            $path = [static::$defaultPage];
         }
 
         // crawl down path stack until a handler is found
-        $searchPath = array('site-root');
+        $searchPath = ['site-root'];
         while ($handle = array_shift($path)) {
             $foundNode = null;
 
             // if path component doesn't already end in .php, check for a .php match first
-            if (substr($handle, -4) != '.php') {
+            if (!str_ends_with((string) $handle, '.php')) {
                 array_push($searchPath, $handle.'.php');
                 $foundNode = static::resolvePath($searchPath);
                 array_pop($searchPath);
@@ -372,7 +370,7 @@ class Site
 
             $createSession = true;
             foreach (static::$skipSessionPaths as $skipSessionPath) {
-                if (strpos($resolvedPath, $skipSessionPath) === 0) {
+                if (str_starts_with($resolvedPath, (string) $skipSessionPath)) {
                     $createSession = false;
                     break;
                 }
@@ -396,11 +394,11 @@ class Site
             call_user_func(static::$onBeforeScriptExecute, $_SCRIPT_NODE);
         }
 
-        if (class_exists('Emergence\\EventBus')) {
-            Emergence\EventBus::fireEvent('beforeScriptExecute', 'Site', array(
+        if (class_exists(\Emergence\EventBus::class)) {
+            Emergence\EventBus::fireEvent('beforeScriptExecute', 'Site', [
                 'node' => $_SCRIPT_NODE,
                 'exit' => $_SCRIPT_EXIT
-            ));
+            ]);
         }
 
         require($_SCRIPT_NODE->RealPath);
@@ -452,10 +450,10 @@ class Site
         }
 
         // try to load class PSR-0 style
-        if (!preg_match('/^Sabre_/', $className)) {
-            if ($lastNsPos = strrpos($className, '\\')) {
-                $namespace = substr($className, 0, $lastNsPos);
-                $className = substr($className, $lastNsPos + 1);
+        if (!preg_match('/^Sabre_/', (string) $className)) {
+            if ($lastNsPos = strrpos((string) $className, '\\')) {
+                $namespace = substr((string) $className, 0, $lastNsPos);
+                $className = substr((string) $className, $lastNsPos + 1);
                 $fileName  = str_replace('\\', DIRECTORY_SEPARATOR, $namespace).DIRECTORY_SEPARATOR;
             } else {
                 $fileName = '';
@@ -490,7 +488,7 @@ class Site
 
             // invoke __classLoaded
             if (method_exists($fullClassName, '__classLoaded')) {
-                call_user_func(array($fullClassName, '__classLoaded'));
+                call_user_func([$fullClassName, '__classLoaded']);
             }
         }
     }
@@ -503,13 +501,13 @@ class Site
         // TODO: re-enable cache
         // if (!$configFiles = Cache::fetch($cacheKey)) {
             $fs = static::getFilesystem();
-            $configFiles = array();
+            $configFiles = [];
 
 
             // compute file path for given class name
-            if ($lastNsPos = strrpos($className, '\\')) {
-                $namespace = substr($className, 0, $lastNsPos);
-                $className = substr($className, $lastNsPos + 1);
+            if ($lastNsPos = strrpos((string) $className, '\\')) {
+                $namespace = substr((string) $className, 0, $lastNsPos);
+                $className = substr((string) $className, $lastNsPos + 1);
                 $path  = str_replace('\\', DIRECTORY_SEPARATOR, $namespace).DIRECTORY_SEPARATOR;
             } else {
                 $path = '';
@@ -570,8 +568,8 @@ class Site
         $notFoundNode = null;
         while (count($notFoundStack)) { // last iteration is when site-root is all that's left
             if (
-                ($notFoundNode = static::resolvePath(array_merge($notFoundStack, array('_default.php')))) ||
-                ($notFoundNode = static::resolvePath(array_merge($notFoundStack, array('_notfound.php'))))
+                ($notFoundNode = static::resolvePath(array_merge($notFoundStack, ['_default.php']))) ||
+                ($notFoundNode = static::resolvePath(array_merge($notFoundStack, ['_notfound.php'])))
             ) {
                 // calculate pathStack and resolvedPath relative to each handler
                 static::$pathStack = array_slice(static::$requestPath, count($notFoundStack) - 1);
@@ -588,13 +586,13 @@ class Site
         die($message);
     }
 
-    public static function respondBadRequest($message = 'Cannot display resource')
+    public static function respondBadRequest($message = 'Cannot display resource'): never
     {
         header('HTTP/1.0 400 Bad Request');
         die($message);
     }
 
-    public static function respondUnauthorized($message = 'Access denied')
+    public static function respondUnauthorized($message = 'Access denied'): never
     {
         header('HTTP/1.0 403 Forbidden');
         die($message);
@@ -611,7 +609,7 @@ class Site
 
     public static function splitPath($path)
     {
-        return explode('/', ltrim($path, '/'));
+        return explode('/', ltrim((string) $path, '/'));
     }
 
     public static function isUsingHttps()
@@ -636,10 +634,10 @@ class Site
             $path = implode('/', $path);
         }
 
-        if (preg_match('/^https?:\/\//i', $path)) {
+        if (preg_match('/^https?:\/\//i', (string) $path)) {
             $url = $path;
         } else {
-            $url = (static::isUsingHttps() ? 'https' : 'http').'://'.($_SERVER['HTTP_HOST'] ?: Site::getConfig('primary_hostname')).'/'.ltrim($path, '/');
+            $url = (static::isUsingHttps() ? 'https' : 'http').'://'.($_SERVER['HTTP_HOST'] ?: Site::getConfig('primary_hostname')).'/'.ltrim((string) $path, '/');
         }
 
         if ($get) {
@@ -671,14 +669,14 @@ class Site
 
     public static function matchPath($index, $string)
     {
-        return 0==strcasecmp(static::getPath($index), $string);
+        return 0==strcasecmp((string) static::getPath($index), (string) $string);
     }
 
     public static function normalizePath($filename)
     {
         $filename = str_replace('//', '/', $filename);
         $parts = explode('/', $filename);
-        $out = array();
+        $out = [];
         foreach ($parts as $part) {
             if ($part == '.') {
                 continue;
@@ -746,10 +744,10 @@ class Site
 
         Emergence\EventBus::fireEvent(
             'timezoneSet',
-            __CLASS__,
-            array(
+            self::class,
+            [
                 'timezone' => $timezone
-            )
+            ]
         );
     }
 

--- a/src-compat/SiteCollection.php
+++ b/src-compat/SiteCollection.php
@@ -6,27 +6,22 @@ class SiteCollection
     public static $tableName = '_e_file_collections';
     public static $autoCreate = false;
     public static $fileClass = 'SiteFile';
-
-    // protected properties
-    protected $_handle;
     protected $_record;
     protected $_parent;
 
-    public function __construct($handle, $record = null)
+    public function __construct(protected $_handle, $record = null)
     {
-        $this->_handle = $handle;
-
         if ($record) {
             $this->_record = $record;
         } else {
-            $this->_record = static::getRecordByHandle($handle);
+            $this->_record = static::getRecordByHandle($this->_handle);
         }
 
         if (!$this->_record) {
             if (static::$autoCreate) {
-                $this->_record = static::createRecord($handle);
+                $this->_record = static::createRecord($this->_handle);
             } else {
-                throw new Exception('Collection with name '.$handle.' could not be located');
+                throw new Exception('Collection with name '.$this->_handle.' could not be located');
             }
         }
     }
@@ -37,7 +32,7 @@ class SiteCollection
             case 'ID':
                 return $this->_record['path'];
             case 'Class':
-                return __CLASS__;
+                return self::class;
             case 'Handle':
                 return $this->_handle;
             case 'Status':
@@ -99,7 +94,7 @@ class SiteCollection
     {
         // build cache key and query conditions
         $cacheKey = static::getCacheKey($handle, $parentID, $remote);
-        $where = array();
+        $where = [];
 
         if ($parentID) {
             $where[] = sprintf('ParentID = %u', $parentID);
@@ -124,10 +119,10 @@ class SiteCollection
         // query and cache
         $record = DB::oneRecord(
             'SELECT * FROM `%s` WHERE (%s) ORDER BY ID DESC LIMIT 1'
-            ,array(
+            ,[
                 static::$tableName
                 ,implode(') AND (', $where)
-            )
+            ]
         );
 
         Cache::store($cacheKey, $record);
@@ -139,23 +134,23 @@ class SiteCollection
     {
         DB::nonQuery('LOCK TABLES '.static::$tableName.' READ');
 
-        $positions = DB::oneRecord('SELECT PosLeft, PosRight FROM `%s` WHERE ID = %u', array(
+        $positions = DB::oneRecord('SELECT PosLeft, PosRight FROM `%s` WHERE ID = %u', [
             static::$tableName
             ,$this->ID
-        ));
+        ]);
 
         $collectionResults = DB::query(
             'SELECT * FROM `%1$s` WHERE PosLeft BETWEEN %2$u AND %3$u AND Status = "Normal"'
-            ,array(
+            ,[
                 static::$tableName
                 ,$positions['PosLeft']
                 ,$positions['PosRight']
-            )
+            ]
         );
 
         DB::nonQuery('UNLOCK TABLES');
 
-        $children = array();
+        $children = [];
         while ($record = $collectionResults->fetch_assoc()) {
             $children[] = new static($record['Handle'], $record);
         }
@@ -178,15 +173,15 @@ class SiteCollection
     public function getChildren()
     {
         $fileClass = static::$fileClass;
-        $children = array();
+        $children = [];
 
         // get collections
         $collectionResults = DB::query(
             'SELECT * FROM `%s` WHERE ParentID = %u AND Status = "Normal"'
-            ,array(
+            ,[
                 static::$tableName
                 ,$this->ID
-            )
+            ]
         );
 
         while ($record = $collectionResults->fetch_assoc()) {
@@ -196,10 +191,10 @@ class SiteCollection
         // get files
         $fileResults = DB::query(
             'SELECT f2.* FROM (SELECT MAX(f1.ID) AS ID FROM `%1$s` f1 WHERE CollectionID = %2$u AND Status != "Phantom" GROUP BY f1.Handle) AS lastestFiles LEFT JOIN `%1$s` f2 ON (f2.ID = lastestFiles.ID) WHERE f2.Status = "Normal"'
-            ,array(
+            ,[
                 $fileClass::$tableName
                 ,$this->ID
-            )
+            ]
         );
 
         while ($record = $fileResults->fetch_assoc()) {
@@ -283,7 +278,7 @@ class SiteCollection
         }
 
         // discover parent tree
-        $tree = array($node = $this);
+        $tree = [$node = $this];
         while ($node->ParentID) {
             $tree[] = $node = static::getByID($node->ParentID);
         }
@@ -383,21 +378,21 @@ class SiteCollection
         // check for existing deleted node
         $existingRecord = DB::oneRecord(
             'SELECT * FROM `%s` WHERE Site = "%s" AND ParentID = %s AND Handle = "%s"'
-            ,array(
+            ,[
                 static::$tableName
                 ,$parentCollection ? $parentCollection->Site : ($remote ? 'Remote' : 'Local')
                 ,$parentCollection ? $parentCollection->ID : 'NULL'
                 ,DB::escape($handle)
-            )
+            ]
         );
 
         if ($existingRecord) {
             DB::nonQuery(
                 'UPDATE `%s` SET Status = "Normal" WHERE ID = %u'
-                ,array(
+                ,[
                     static::$tableName
                     ,$existingRecord['ID']
-                )
+                ]
             );
 
             return $existingRecord['ID'];
@@ -409,7 +404,7 @@ class SiteCollection
         try {
             // determine new node's position
             if ($parentCollection) {
-                $left = DB::oneValue('SELECT PosRight FROM `%s` WHERE ID = %u', array(static::$tableName, $parentCollection->ID));
+                $left = DB::oneValue('SELECT PosRight FROM `%s` WHERE ID = %u', [static::$tableName, $parentCollection->ID]);
             } else {
                 $left = DB::oneValue('SELECT IFNULL(MAX(PosRight)+1, 1) FROM `%s`', static::$tableName);
             }
@@ -419,22 +414,22 @@ class SiteCollection
                 // push rest of set right by 2 to make room
                 DB::nonQuery(
                     'UPDATE `%s` SET PosRight = PosRight + 2 WHERE PosRight >= %u ORDER BY PosRight DESC'
-                    ,array(
+                    ,[
                         static::$tableName
                         ,$left
-                    )
+                    ]
                 );
                 DB::nonQuery(
                     'UPDATE `%s` SET PosLeft = PosLeft + 2 WHERE PosLeft > %u ORDER BY PosLeft DESC'
-                    ,array(
+                    ,[
                         static::$tableName
                         ,$left
-                    )
+                    ]
                 );
             }
 
             // create record
-            DB::nonQuery('INSERT INTO `%s` SET Site = "%s", Handle = "%s", CreatorID = %u, ParentID = %s, PosLeft = %u, PosRight = %u', array(
+            DB::nonQuery('INSERT INTO `%s` SET Site = "%s", Handle = "%s", CreatorID = %u, ParentID = %s, PosLeft = %u, PosRight = %u', [
                 static::$tableName
                 ,$parentCollection ? $parentCollection->Site : ($remote ? 'Remote' : 'Local')
                 ,DB::escape($handle)
@@ -442,7 +437,7 @@ class SiteCollection
                 ,$parentCollection ? $parentCollection->ID : 'NULL'
                 ,$left
                 ,$right
-            ));
+            ]);
 
             $newID = DB::insertID();
         } catch (Exception $e) {
@@ -462,11 +457,11 @@ class SiteCollection
         Cache::delete(static::getCacheKey($handle, $this->ParentID, $this->Site == 'Remote'));
         Cache::delete('efs:col:'.$this->ID);
 
-        DB::nonQuery('UPDATE `%s` SET Handle = "%s" WHERE ID = %u', array(
+        DB::nonQuery('UPDATE `%s` SET Handle = "%s" WHERE ID = %u', [
             static::$tableName
             ,DB::escape($handle)
             ,$this->ID
-        ));
+        ]);
     }
 
     public function setStatus($status)
@@ -474,11 +469,11 @@ class SiteCollection
         Cache::delete(static::getCacheKey($this->Handle, $this->ParentID, $this->Site == 'Remote'));
         Cache::delete('efs:col:'.$this->ID);
 
-        DB::nonQuery('UPDATE `%s` SET Status = "%s" WHERE ID = %u', array(
+        DB::nonQuery('UPDATE `%s` SET Status = "%s" WHERE ID = %u', [
             static::$tableName
             ,DB::escape($status)
             ,$this->ID
-        ));
+        ]);
     }
 
     public function getLastModified()
@@ -492,17 +487,17 @@ class SiteCollection
 
         DB::nonQuery('LOCK TABLES '.static::$tableName.' WRITE');
 
-        $positions = DB::oneRecord('SELECT PosLeft, PosRight FROM `%s` WHERE ID = %u', array(
+        $positions = DB::oneRecord('SELECT PosLeft, PosRight FROM `%s` WHERE ID = %u', [
             static::$tableName
             ,$this->ID
-        ));
+        ]);
 
         // mark collection and all subcollections as deleted
-        DB::nonQuery('UPDATE `%s` SET Status = "Deleted" WHERE PosLeft BETWEEN %u AND %u', array(
+        DB::nonQuery('UPDATE `%s` SET Status = "Deleted" WHERE PosLeft BETWEEN %u AND %u', [
             static::$tableName
             ,$positions['PosLeft']
             ,$positions['PosRight']
-        ));
+        ]);
 
         DB::nonQuery('UNLOCK TABLES');
 

--- a/src-compat/SiteFile.php
+++ b/src-compat/SiteFile.php
@@ -6,7 +6,7 @@ class SiteFile
     public static $tableName = '_e_files';
     public static $dataPath = 'data';
     public static $collectionClass = 'SiteCollection';
-    public static $extensionMIMETypes = array(
+    public static $extensionMIMETypes = [
         'js' => 'application/javascript'
         ,'json' => 'application/json'
         ,'php' => 'application/php'
@@ -21,9 +21,9 @@ class SiteFile
         ,'svg' => 'image/svg+xml'
         ,'yml' => 'application/x-yaml'
         ,'yaml' => 'application/x-yaml'
-    );
-    public static $additionalHeaders = array(
-        'static' => array('Cache-Control: max-age=3600, must-revalidate', 'Pragma: public')
+    ];
+    public static $additionalHeaders = [
+        'static' => ['Cache-Control: max-age=3600, must-revalidate', 'Pragma: public']
         ,'image/png' => 'static'
         ,'image/jpeg' => 'static'
         ,'image/gif' => 'static'
@@ -36,16 +36,10 @@ class SiteFile
         ,'font/ttf' => 'static'
         ,'application/vnd.ms-fontobject' => 'static'
         ,'image/svg+xml' => 'static'
-    );
+    ];
 
-    // private properties
-    private $_handle;
-    private $_record;
-
-    public function __construct($handle, $record = null)
+    public function __construct(private $_handle, private $_record = null)
     {
-        $this->_handle = $handle;
-        $this->_record = $record;
     }
 
     protected $_mimeType;
@@ -58,7 +52,7 @@ class SiteFile
             case 'ID':
                 return $this->_record['path'];
             case 'Class':
-                return __CLASS__;
+                return self::class;
             case 'Handle':
                 return $this->_handle;
             case 'Type':
@@ -140,11 +134,11 @@ class SiteFile
         if (false === ($record = Cache::fetch($cacheKey))) {
             $record = DB::oneRecord(
                 'SELECT * FROM `%s` WHERE CollectionID = %u AND Handle = "%s" ORDER BY ID DESC LIMIT 1'
-                ,array(
+                ,[
                     static::$tableName
                     ,$collectionID
                     ,DB::escape($handle)
-                )
+                ]
             );
 
             // don't cache the temporary "Phantom" records created as placeholders during write
@@ -160,24 +154,24 @@ class SiteFile
     {
         DB::nonQuery('LOCK TABLES '.static::$tableName.' f1 READ, '.static::$tableName.' f2 READ, '.SiteCollection::$tableName.' collections READ');
 
-        $positions = DB::oneRecord('SELECT PosLeft, PosRight FROM `%s` collections WHERE ID = %u', array(
+        $positions = DB::oneRecord('SELECT PosLeft, PosRight FROM `%s` collections WHERE ID = %u', [
             SiteCollection::$tableName
             ,$Collection->ID
-        ));
+        ]);
 
         $fileResults = DB::query(
             'SELECT f2.* FROM (SELECT MAX(f1.ID) AS ID FROM `%1$s` f1 WHERE CollectionID IN (SELECT collections.ID FROM `%2$s` collections WHERE PosLeft BETWEEN %3$u AND %4$u) AND Status != "Phantom" GROUP BY f1.Handle) AS lastestFiles LEFT JOIN `%1$s` f2 ON (f2.ID = lastestFiles.ID) WHERE f2.Status != "Deleted"'
-            ,array(
+            ,[
                 static::$tableName
                 ,SiteCollection::$tableName
                 ,$positions['PosLeft']
                 ,$positions['PosRight']
-            )
+            ]
         );
 
         DB::nonQuery('UNLOCK TABLES');
 
-        $children = array();
+        $children = [];
         while ($record = $fileResults->fetch_assoc()) {
             $children[] = new static($record['Handle'], $record);
         }
@@ -189,14 +183,14 @@ class SiteFile
     {
         $result = DB::query(
             'SELECT * FROM `%s` WHERE CollectionID = %u AND Handle = "%s" ORDER BY ID DESC'
-            ,array(
+            ,[
                 static::$tableName
                 ,$this->CollectionID
                 ,DB::escape($this->Handle)
-            )
+            ]
         );
 
-        $revisions = array();
+        $revisions = [];
         while ($record = $result->fetch_assoc()) {
             $revisions[] = new static($record['Handle'], $record);
         }
@@ -277,9 +271,9 @@ class SiteFile
         $collectionClass = static::$collectionClass;
         $path = $collectionClass::getByID($collectionID)->getFullPath(null, false);
         $path[] = $handle;
-        static::fireFileEvent($path, 'fileWrite', array(
+        static::fireFileEvent($path, 'fileWrite', [
             'record' => $record
-        ));
+        ]);
 
         return $record;
     }
@@ -298,14 +292,14 @@ class SiteFile
         } elseif ($this->Status == 'Normal' && $this->SHA1 == $sha1) {
             return $this->_record;
         } else {
-            $record = static::createPhantom($this->CollectionID, $this->Handle, $ancestorID ? $ancestorID : $this->ID);
+            $record = static::createPhantom($this->CollectionID, $this->Handle, $ancestorID ?: $this->ID);
             static::saveRecordData($record, $data, $sha1);
         }
 
         // fire event
-        static::fireFileEvent($this->getFullPath(null, false), 'fileWrite', array(
+        static::fireFileEvent($this->getFullPath(null, false), 'fileWrite', [
             'record' => $record
-        ));
+        ]);
 
         return $record;
     }
@@ -314,16 +308,16 @@ class SiteFile
     {
         $timestamp = date('Y-m-d H:i:s');
 
-        DB::nonQuery('INSERT INTO `%s` SET CollectionID = %u, Handle = "%s", Status = "Phantom", Timestamp = "%s", AuthorID = %s, AncestorID = %s', array(
+        DB::nonQuery('INSERT INTO `%s` SET CollectionID = %u, Handle = "%s", Status = "Phantom", Timestamp = "%s", AuthorID = %s, AncestorID = %s', [
             static::$tableName
             ,$collectionID
             ,DB::escape($handle)
             ,$timestamp
             ,!empty($GLOBALS['Session']) && $GLOBALS['Session']->PersonID ? $GLOBALS['Session']->PersonID : 'NULL'
-            ,$ancestorID ? $ancestorID : 'NULL'
-        ));
+            ,$ancestorID ?: 'NULL'
+        ]);
 
-        return array(
+        return [
             'ID' => DB::insertID()
             ,'CollectionID' => $collectionID
             ,'Handle' => $handle
@@ -331,7 +325,7 @@ class SiteFile
             ,'Timestamp' => $timestamp
             ,'AuthorID' => !empty($GLOBALS['Session']) && $GLOBALS['Session']->PersonID ? $GLOBALS['Session']->PersonID : null
             ,'AncestorID' => $ancestorID
-        );
+        ];
     }
 
     public static function saveRecordData(&$record, $data, $sha1 = null)
@@ -346,7 +340,7 @@ class SiteFile
         }
 
         // update in-memory record
-        $record['SHA1'] = $sha1 ? $sha1 : sha1_file($filePath);
+        $record['SHA1'] = $sha1 ?: sha1_file($filePath);
         $record['Size'] = filesize($filePath);
         $record['Type'] = File::getMIMEType($filePath);
         $record['Status'] = 'Normal';
@@ -360,14 +354,14 @@ class SiteFile
         }
 
         // write record to database
-        DB::nonQuery('UPDATE `%s` SET SHA1 = "%s", Size = %u, Type = "%s", Timestamp = "%s", Status = "Normal" WHERE ID = %u', array(
+        DB::nonQuery('UPDATE `%s` SET SHA1 = "%s", Size = %u, Type = "%s", Timestamp = "%s", Status = "Normal" WHERE ID = %u', [
             static::$tableName
             ,$record['SHA1']
             ,$record['Size']
             ,$record['Type']
             ,$record['Timestamp']
             ,$record['ID']
-        ));
+        ]);
 
         // invalidate cache
         Cache::delete(static::getCacheKey($record['CollectionID'], $record['Handle']));
@@ -381,18 +375,18 @@ class SiteFile
 
         if ($this->Size == 0 && $authorID && $this->AuthorID == $authorID && !$this->AncestorID) {
             // updating existing record only if file is empty, by the same author, and has no ancestor
-            DB::nonQuery('UPDATE `%s` SET Handle = "%s", Timestamp = "%s" WHERE ID = %u', array(
+            DB::nonQuery('UPDATE `%s` SET Handle = "%s", Timestamp = "%s" WHERE ID = %u', [
                 static::$tableName
                 ,DB::escape($handle)
                 ,$timestamp
                 ,$this->ID
-            ));
+            ]);
             $this->_record['Timestamp'] = $timestamp;
         } else {
             // clone existing record
             DB::nonQuery(
                 'INSERT INTO `%s` SET CollectionID = %u, Handle = "%s", Status = "%s", SHA1 = "%s", Size = %u, Type = "%s", Timestamp = "%s", AuthorID = %s, AncestorID = %u'
-                ,array(
+                ,[
                     static::$tableName
                     ,$this->CollectionID
                     ,DB::escape($handle)
@@ -401,9 +395,9 @@ class SiteFile
                     ,$this->Size
                     ,$this->Type
                     ,$timestamp
-                    ,$this->AuthorID ? $this->AuthorID : 'NULL'
+                    ,$this->AuthorID ?: 'NULL'
                     ,$this->ID
-                )
+                ]
             );
             $newID = DB::insertID();
 
@@ -431,39 +425,39 @@ class SiteFile
         Cache::delete(static::getCacheKey($this->CollectionID, $handle));
 
         // fire event
-        static::fireFileEvent($this->getFullPath(null, false), 'fileRename', array(
+        static::fireFileEvent($this->getFullPath(null, false), 'fileRename', [
             'record' => $this->_record,
             'oldHandle' => $oldHandle,
             'newHandle' => $handle
-        ));
+        ]);
     }
 
     public function delete()
     {
-        DB::nonQuery('INSERT INTO `%s` SET CollectionID = %u, Handle = "%s", Status = "Deleted", Timestamp = "%s", AuthorID = %s, AncestorID = %u', array(
+        DB::nonQuery('INSERT INTO `%s` SET CollectionID = %u, Handle = "%s", Status = "Deleted", Timestamp = "%s", AuthorID = %s, AncestorID = %u', [
             static::$tableName
             ,$this->CollectionID
             ,DB::escape($this->Handle)
             ,date('Y-m-d H:i:s')
             ,!empty($GLOBALS['Session']) && $GLOBALS['Session']->PersonID ? $GLOBALS['Session']->PersonID : 'NULL'
             ,$this->ID
-        ));
+        ]);
 
         // invalidate cache
         Cache::delete(static::getCacheKey($this->CollectionID, $this->Handle));
 
         // fire event
-        static::fireFileEvent($this->getFullPath(null, false), 'fileDelete', array(
+        static::fireFileEvent($this->getFullPath(null, false), 'fileDelete', [
             'record' => $this->_record
-        ));
+        ]);
     }
 
     public function destroyRecord()
     {
-        DB::nonQuery('DELETE FROM `%s` WHERE ID = %u', array(
+        DB::nonQuery('DELETE FROM `%s` WHERE ID = %u', [
             static::$tableName
             ,$this->ID
-        ));
+        ]);
 
         // invalidate cache
         Cache::delete(static::getCacheKey($this->CollectionID, $this->Handle));
@@ -479,21 +473,21 @@ class SiteFile
     {
         DB::nonQuery('LOCK TABLES '.static::$tableName.' WRITE, '.static::$tableName.' AS f1 READ, '.static::$tableName.' AS f2 READ, '.SiteCollection::$tableName.' AS collections READ');
 
-        $positions = DB::oneRecord('SELECT PosLeft, PosRight FROM `%s` collections WHERE ID = %u', array(
+        $positions = DB::oneRecord('SELECT PosLeft, PosRight FROM `%s` collections WHERE ID = %u', [
             SiteCollection::$tableName
             ,$Collection->ID
-        ));
+        ]);
 
         DB::nonQuery(
             'INSERT INTO `%1$s` (CollectionID, Handle, Status, Timestamp, AuthorID, AncestorID) SELECT f2.CollectionID, f2.Handle, "Deleted", "%5$s", %6$s, f2.ID FROM (SELECT MAX(f1.ID) AS ID FROM `%1$s` f1 WHERE CollectionID IN (SELECT collections.ID FROM `%2$s` collections WHERE PosLeft BETWEEN %3$u AND %4$u) AND Status != "Phantom" GROUP BY f1.Handle) AS lastestFiles LEFT JOIN `%1$s` f2 ON (f2.ID = lastestFiles.ID) WHERE f2.Status != "Deleted"'
-            ,array(
+            ,[
                 static::$tableName
                 ,SiteCollection::$tableName
                 ,$positions['PosLeft']
                 ,$positions['PosRight']
                 ,date('Y-m-d H:i:s')
                 ,!empty($GLOBALS['Session']) && $GLOBALS['Session']->PersonID ? $GLOBALS['Session']->PersonID : 'NULL'
-            )
+            ]
         );
 
         DB::nonQuery('UNLOCK TABLES');
@@ -566,12 +560,12 @@ class SiteFile
         return $data;
     }
 
-    public static function fireFileEvent($path, $event, $payload = array())
+    public static function fireFileEvent($path, $event, $payload = [])
     {
-        if (!class_exists('Emergence\\EventBus')) {
+        if (!class_exists(\Emergence\EventBus::class)) {
             return;
         }
 
-        return \Emergence\EventBus::fireEvent($event, array_merge(array('Emergence', 'FS'), $path), $payload);
+        return \Emergence\EventBus::fireEvent($event, array_merge(['Emergence', 'FS'], $path), $payload);
     }
 }

--- a/src/EventBus.php
+++ b/src/EventBus.php
@@ -8,14 +8,14 @@ use Emergence_FS;
 
 class EventBus
 {
-    public static function fireEvent($name, $context, $payload = array())
+    public static function fireEvent($name, $context, $payload = [])
     {
-        $_EVENT = array_merge($payload, array(
+        $_EVENT = array_merge($payload, [
             'NAME' => $name,
             'CONTEXT' => $context,
             'HANDLERS' => static::getHandlers($name, $context),
-            'RESULTS' => array()
-        ));
+            'RESULTS' => []
+        ]);
 
         foreach ($_EVENT['HANDLERS'] as $sitePath => $fileSystemPath) {
             $_EVENT['CURRENT_HANDLER_PATH'] = $sitePath;
@@ -49,7 +49,7 @@ class EventBus
         }
 
         $contextOriginalLength = count($context);
-        $handlers = array();
+        $handlers = [];
         Emergence_FS::cacheTree($rootCollection);
 
         while (true) {

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -70,7 +70,7 @@ class Logger extends \Psr\Log\AbstractLogger
             $targets = !empty($config['targets']) ? $config['targets'] : [];
         }
 
-        return isset($targets[$name]) ? $targets[$name] : null;
+        return $targets[$name] ?? null;
     }
 
 
@@ -115,7 +115,7 @@ class Logger extends \Psr\Log\AbstractLogger
         static::$instances[$target] = $logger;
     }
 
-    public function log($level, $message, array $context = array())
+    public function log($level, $message, array $context = [])
     {
         if (static::getDump()) {
             dump([
@@ -151,7 +151,7 @@ class Logger extends \Psr\Log\AbstractLogger
                 '<dl>'
                     .'<dt>Timestamp</dt><dd>'.date('Y-m-d H:i:s').'</dd>'
                     .'<dt>Level</dt><dd>'.$level.'</dd>'
-                    .'<dt>Message</dt><dd>'.htmlspecialchars($message).'</dd>'
+                    .'<dt>Message</dt><dd>'.htmlspecialchars((string) $message).'</dd>'
                     .'<dt>Context</dt><dd><pre>'.htmlspecialchars(print_r($context, true)).'</pre></dd>'
                     .'<dt>Backtrace</dt><dd><pre>'.htmlspecialchars(implode("\n", static::buildBacktraceLines($frames))).'</pre></dd>'
             );
@@ -167,13 +167,13 @@ class Logger extends \Psr\Log\AbstractLogger
         }
 
         // build friendly output lines from backtrace frames
-        $lines = array();
+        $lines = [];
         foreach ($frames as $frame) {
             if (!is_array($frame)) {
                 $frame = $frame->getRawFrame();
             }
 
-            if (!empty($frame['file']) && strpos($frame['file'], \Site::$rootPath.'/data/') === 0) {
+            if (!empty($frame['file']) && str_starts_with($frame['file'], \Site::$rootPath.'/data/')) {
                 $fileNode = \SiteFile::getByID(basename($frame['file']));
 
                 if ($fileNode) {
@@ -189,7 +189,7 @@ class Logger extends \Psr\Log\AbstractLogger
                     $frame['file'] == 'emergence:_parent/php-classes/Emergence/Logger.php'
                 ) ||
                 (empty($frame['file']) && !empty($frame['class']) && $frame['class'] == 'Psr\Log\AbstractLogger') ||
-                (!empty($frame['class']) && $frame['class'] == 'Emergence\Logger' && !empty($frame['function']) && $frame['function'] == '__callStatic')
+                (!empty($frame['class']) && $frame['class'] == \Emergence\Logger::class && !empty($frame['function']) && $frame['function'] == '__callStatic')
             ) {
                 continue;
             }
@@ -198,9 +198,7 @@ class Logger extends \Psr\Log\AbstractLogger
                  (!empty($frame['class']) ? $frame['class'] : '')
                 .(!empty($frame['type']) ? $frame['type'] : '')
                 .(!empty($frame['function']) ? $frame['function'] : '')
-                .(!empty($frame['args']) ? '('.implode(',', array_map(function($arg) {
-                    return is_string($arg) || is_numeric($arg) ? var_export($arg, true) : gettype($arg);
-                }, $frame['args'])).')' : '')
+                .(!empty($frame['args']) ? '('.implode(',', array_map(fn($arg) => is_string($arg) || is_numeric($arg) ? var_export($arg, true) : gettype($arg), $frame['args'])).')' : '')
                 .(!empty($frame['file']) ? " called at $frame[file]:$frame[line]" : '');
         }
 
@@ -260,7 +258,7 @@ class Logger extends \Psr\Log\AbstractLogger
     public static function __callStatic($method, $arguments)
     {
         if (
-            preg_match('/^([^_]+)_(.*)$/', $method, $matches)
+            preg_match('/^([^_]+)_(.*)$/', (string) $method, $matches)
             && ($logger = static::getLogger($matches[1]))
             && method_exists($logger, $matches[2])
         ) {


### PR DESCRIPTION
## Summary

The PHP 8 port for the Track A live-site modernization, seeded from the prototype that proved this core boots and renders Slate on PHP 8.3 against MySQL 8 (nginx → PHP-FPM 8.3 → `Site::initialize` → routing → Dwoo render → HTTP 200). Four commits:

1. **fix(db)** — `mysqli_report(MYSQLI_REPORT_OFF)` before connecting (PHP 8.1 defaults mysqli to exception mode, which bypasses `DB::handleError`'s errno checks and kills the `TableNotFoundException` → auto-create-table flow), plus `ENGINE=MyISAM` → `ENGINE=InnoDB` rewrite in `DB::preprocessQuery` (MySQL 8 / Cloud SQL retire MyISAM).
2. **fix(site)** — `Site::initialize()` optional-before-required parameter signature (`array $config` → `array $config = []`), a PHP 8.0 deprecation that warns on 8.3.
3. **build(composer)** — explicit `php ^8.1`, PHP 8-capable dependency lines (var-dumper ^5.4, whoops ^2.15, flysystem ^1.1 staying on the 1.x API `Site::getFilesystem()` uses, psr/log ^1.1), lock regenerated.
4. **refactor** — Rector `LevelSetList::UP_TO_PHP_83` sweep (15 files; mechanical modernization only — the dry-run surfaced no additional fatal-class findings beyond the targeted fixes above).

## Testing

- `php -l` clean across all 21 files in `handlers/`, `src/`, `src-compat/` on PHP 8.3.
- The commit-1/2 changes are byte-equivalent to the prototype patch verified end-to-end (HTTP 200 framework-rendered pages, InnoDB auto-created tables on MySQL 8).
- This branch is consumed as the Composer dependency of `EmergencePlatform/skeleton-v3`, where it gets re-verified in the composed container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)